### PR TITLE
Introduces notification collection representation pagination.

### DIFF
--- a/src/main/java/api/NotificationResource.java
+++ b/src/main/java/api/NotificationResource.java
@@ -30,6 +30,8 @@ public interface NotificationResource {
    * @param headers The headers from the HTTP request.
    * @param uriInfo Information about the URI of the HTTP request.
    * @param messageExternalID The external identifier of a message associated with a notification.
+   * @param skip The number of notifications to skip when in the collection.
+   * @param take The maximum number of notifications to return in the response.
    * @return The HTTP {@link Response}, including the representations of the requested notification
    *     collection.
    */
@@ -37,7 +39,9 @@ public interface NotificationResource {
   Response getCollection(
       @Context HttpHeaders headers,
       @Context UriInfo uriInfo,
-      @QueryParam("messageExternalID") String messageExternalID);
+      @QueryParam("messageExternalID") String messageExternalID,
+      @QueryParam("skip") Integer skip,
+      @QueryParam("take") Integer take);
 
   /**
    * Handles HTTP GET requests for the notification with the unique identifier provided.

--- a/src/main/java/api/representations/RepresentationFactory.java
+++ b/src/main/java/api/representations/RepresentationFactory.java
@@ -52,7 +52,7 @@ public abstract class RepresentationFactory {
       URI location, Locale language, Notification notification);
 
   /**
-   * Constructs an audience epresentation.
+   * Constructs an audience representation.
    *
    * @param location The content location of the audience representation.
    * @param language The content language of the audience representation.
@@ -73,6 +73,23 @@ public abstract class RepresentationFactory {
   public abstract Representation createTargetRepresentation(
       URI location, Locale language, Target target);
 
+  /**
+   * Constructs a notification collection representation.
+   *
+   * @param location The content location of the notification collection representation.
+   * @param language The content language of the notification collection representation.
+   * @param notifications The notification collection state expressed by the notification collection
+   *     representation being constructed.
+   * @param skip The number of notifications skipped (in previous pages).
+   * @param take The maximum number of notifications in the current page of the collection.
+   * @param total The total number of notifications in the collection (not the current page).
+   * @return The notification collection representation.
+   */
   public abstract Representation createNotificationCollectionRepresentation(
-      URI location, Locale language, Set<Notification> notifications);
+      URI location,
+      Locale language,
+      Set<Notification> notifications,
+      Integer skip,
+      Integer take,
+      Integer total);
 }

--- a/src/main/java/api/representations/json/JSONRepresentationFactory.java
+++ b/src/main/java/api/representations/json/JSONRepresentationFactory.java
@@ -164,7 +164,12 @@ public final class JSONRepresentationFactory extends RepresentationFactory {
 
   @Override
   public Representation createNotificationCollectionRepresentation(
-      URI location, Locale language, Set<Notification> notifications) {
+      URI location,
+      Locale language,
+      Set<Notification> notifications,
+      Integer skip,
+      Integer take,
+      Integer total) {
     Span span =
         this.tracer
             .buildSpan("JSONRepresentationFactory#createNotificationCollectionRepresentation")
@@ -179,7 +184,7 @@ public final class JSONRepresentationFactory extends RepresentationFactory {
             this.createNotificationRepresentation(location, language, notification);
         builder.addNotification(notificationRepresentation);
       }
-      return builder.build();
+      return builder.total(total).build();
     } finally {
       span.finish();
     }

--- a/src/main/java/api/representations/json/NotificationCollection.java
+++ b/src/main/java/api/representations/json/NotificationCollection.java
@@ -8,20 +8,24 @@ import javax.ws.rs.core.MediaType;
 // TODO make this a generic RepresentationCollection class.
 public final class NotificationCollection extends Representation {
 
+  private int total;
   private Set<Representation> notifications;
 
   private NotificationCollection() {
     super(MediaType.APPLICATION_JSON_TYPE);
     this.notifications = new HashSet<>();
+    this.total = 0;
   }
 
   public static final class Builder extends Representation.Builder {
 
+    private int total;
     private Set<Representation> notifications;
 
     public Builder() {
       super(MediaType.APPLICATION_JSON_TYPE);
       this.notifications = new HashSet<>();
+      this.total = 0;
     }
 
     public Builder addNotification(Representation notification) {
@@ -29,10 +33,16 @@ public final class NotificationCollection extends Representation {
       return this;
     }
 
+    public Builder total(int total) {
+      this.total = total;
+      return this;
+    }
+
     @Override
     public Representation build() {
       NotificationCollection nc = new NotificationCollection();
       nc.setNotifications(this.notifications);
+      nc.setTotal(this.total);
       return nc;
     }
   }
@@ -43,5 +53,13 @@ public final class NotificationCollection extends Representation {
 
   public Set<Representation> getNotifications() {
     return this.notifications;
+  }
+
+  private void setTotal(int total) {
+    this.total = total;
+  }
+
+  public int getTotal() {
+    return this.total;
   }
 }

--- a/src/main/java/api/representations/xml/NotificationCollection.java
+++ b/src/main/java/api/representations/xml/NotificationCollection.java
@@ -11,20 +11,24 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement(name = "notificationCollection")
 public final class NotificationCollection extends Representation {
 
+  private int total;
   private Set<Representation> notifications;
 
   private NotificationCollection() {
     super(MediaType.APPLICATION_XML_TYPE);
     this.notifications = new HashSet<>();
+    this.total = 0;
   }
 
   public static final class Builder extends Representation.Builder {
 
+    private int total;
     private Set<Representation> notifications;
 
     public Builder() {
       super(MediaType.APPLICATION_XML_TYPE);
       this.notifications = new HashSet<>();
+      this.total = 0;
     }
 
     public Builder addNotification(Representation notification) {
@@ -32,10 +36,16 @@ public final class NotificationCollection extends Representation {
       return this;
     }
 
+    public Builder total(int total) {
+      this.total = total;
+      return this;
+    }
+
     @Override
     public Representation build() {
       NotificationCollection nc = new NotificationCollection();
       nc.setNotifications(this.notifications);
+      nc.setTotal(this.total);
       return nc;
     }
   }
@@ -48,5 +58,14 @@ public final class NotificationCollection extends Representation {
   @XmlElement(name = "notification")
   public Set<Representation> getNotifications() {
     return this.notifications;
+  }
+
+  private void setTotal(int total) {
+    this.total = total;
+  }
+
+  @XmlElement
+  public int getTotal() {
+    return this.total;
   }
 }

--- a/src/main/java/api/representations/xml/XMLRepresentationFactory.java
+++ b/src/main/java/api/representations/xml/XMLRepresentationFactory.java
@@ -156,7 +156,12 @@ public final class XMLRepresentationFactory extends RepresentationFactory {
 
   @Override
   public Representation createNotificationCollectionRepresentation(
-      URI location, Locale language, Set<Notification> notifications) {
+      URI location,
+      Locale language,
+      Set<Notification> notifications,
+      Integer skip,
+      Integer take,
+      Integer total) {
     Span span =
         this.tracer
             .buildSpan("XMLRepresentationFactory#createNotificationCollectionRepresentation")
@@ -171,7 +176,7 @@ public final class XMLRepresentationFactory extends RepresentationFactory {
             this.createNotificationRepresentation(location, language, notification);
         builder.addNotification(notificationRepresentation);
       }
-      return builder.build();
+      return builder.total(total).build();
     } finally {
       span.finish();
     }

--- a/src/main/java/api/resources/NotificationResource.java
+++ b/src/main/java/api/resources/NotificationResource.java
@@ -74,14 +74,16 @@ public class NotificationResource implements api.NotificationResource {
    * @return {@inheritDoc}
    */
   @Override
-  public Response getCollection(HttpHeaders headers, UriInfo uriInfo, String messageExternalID) {
+  public Response getCollection(
+      HttpHeaders headers, UriInfo uriInfo, String messageExternalID, Integer skip, Integer take) {
     Span span = this.tracer.buildSpan("NotificationResource#get").start();
     try (Scope scope = this.tracer.scopeManager().activate(span, false)) {
       URI location = uriInfo.getRequestUri();
       Locale language = null;
 
       Set<application.Notification> notifications =
-          this.notificationService.getNotifications(messageExternalID);
+          this.notificationService.getNotifications(messageExternalID, skip, take);
+      Integer total = this.notificationService.getNotificationCount();
 
       api.representations.Representation representation;
       boolean json = headers.getAcceptableMediaTypes().contains(MediaType.APPLICATION_JSON_TYPE);
@@ -90,15 +92,15 @@ public class NotificationResource implements api.NotificationResource {
       if (json) {
         representation =
             this.jsonRepresentationFactory.createNotificationCollectionRepresentation(
-                location, language, notifications);
+                location, language, notifications, skip, take, total);
       } else if (xml) {
         representation =
             this.xmlRepresentationFactory.createNotificationCollectionRepresentation(
-                location, language, notifications);
+                location, language, notifications, skip, take, total);
       } else {
         representation =
             this.sirenRepresentationFactory.createNotificationCollectionRepresentation(
-                location, language, notifications);
+                location, language, notifications, skip, take, total);
       }
 
       return Response.ok(representation).build();

--- a/src/main/java/application/NotificationService.java
+++ b/src/main/java/application/NotificationService.java
@@ -42,5 +42,7 @@ public interface NotificationService {
    */
   void deleteNotification(UUID uuid);
 
-  Set<Notification> getNotifications(String externalMessageID);
+  Set<Notification> getNotifications(String externalMessageID, Integer skip, Integer take);
+
+  Integer getNotificationCount();
 }

--- a/src/main/java/infrastructure/AudienceDataMapper.java
+++ b/src/main/java/infrastructure/AudienceDataMapper.java
@@ -204,6 +204,21 @@ final class AudienceDataMapper extends DataMapper {
     return sql;
   }
 
+  private String countAudiencesSQL() {
+    DataMap audienceDataMap = this.audienceMetadata.getDataMap();
+    StringBuilder sb =
+        new StringBuilder()
+            .append("SELECT ")
+            .append("COUNT(*) ")
+            .append("FROM ")
+            .append(audienceDataMap.getTableName())
+            .append(" AS ")
+            .append(audienceDataMap.getTableAlias());
+    String sql = sb.toString();
+    this.logger.debug(sql);
+    return sql;
+  }
+
   Set<Audience> findForNotification(UUID notificationUUID) {
 
     // define SQL.
@@ -377,6 +392,20 @@ final class AudienceDataMapper extends DataMapper {
 
       removeAudienceStatement.setString(index, uuid.toString());
       removeAudienceStatement.executeUpdate();
+    } catch (SQLException x) {
+      throw new RuntimeException(x);
+    }
+  }
+
+  int count() {
+
+    final String countAudiencesSQL = this.countAudiencesSQL();
+
+    try (final PreparedStatement countAudiencesStatement =
+            this.getUnitOfWork().createPreparedStatement(countAudiencesSQL);
+        final ResultSet rs = countAudiencesStatement.executeQuery()) {
+      int index = 1;
+      return rs.getInt(index);
     } catch (SQLException x) {
       throw new RuntimeException(x);
     }

--- a/src/main/java/infrastructure/AudienceRepository.java
+++ b/src/main/java/infrastructure/AudienceRepository.java
@@ -133,4 +133,23 @@ public final class AudienceRepository extends SQLRepository implements Repositor
       span.finish();
     }
   }
+
+  /**
+   * Retrieves the number of audiences within the repository.
+   *
+   * @return The number of audiences within the repository.
+   */
+  @Override
+  public int size() {
+    final Span span =
+        this.tracer
+            .buildSpan("AudienceRepository#size")
+            .asChildOf(this.tracer.activeSpan())
+            .start();
+    try (final Scope scope = this.tracer.scopeManager().activate(span, false)) {
+      return this.audienceDataMapper.count();
+    } finally {
+      span.finish();
+    }
+  }
 }

--- a/src/main/java/infrastructure/NotificationDataMapper.java
+++ b/src/main/java/infrastructure/NotificationDataMapper.java
@@ -83,12 +83,12 @@ final class NotificationDataMapper extends DataMapper {
       sb.append(" ORDER BY ").append(orderBy);
     }
 
-    if (skip != null) {
-      sb.append(" OFFSET ").append(skip);
-    }
-
     if (take != null) {
       sb.append(" LIMIT ").append(take);
+    }
+
+    if (skip != null) {
+      sb.append(" OFFSET ").append(skip);
     }
 
     sb.append(";");
@@ -363,6 +363,21 @@ final class NotificationDataMapper extends DataMapper {
     return sql;
   }
 
+  private String countNotificationsSQL() {
+    DataMap notificationDataMap = this.notificationMetadata.getDataMap();
+    StringBuilder sb =
+        new StringBuilder()
+            .append("SELECT ")
+            .append("COUNT(*) ")
+            .append("FROM ")
+            .append(notificationDataMap.getTableName())
+            .append(" AS ")
+            .append(notificationDataMap.getTableAlias());
+    String sql = sb.toString();
+    this.logger.debug(sql);
+    return sql;
+  }
+
   Set<Notification> find(
       String conditions, String orderBy, String skip, String take, List<Query.QueryArgument> args) {
 
@@ -603,6 +618,21 @@ final class NotificationDataMapper extends DataMapper {
       deleteNotificationStatement.setString(index, uuid.toString());
       deleteNotificationStatement.executeUpdate();
 
+    } catch (SQLException x) {
+      throw new RuntimeException(x);
+    }
+  }
+
+  int count() {
+
+    final String countNotificationsSQL = this.countNotificationsSQL();
+
+    try (final PreparedStatement countNotificationsStatement =
+            this.getUnitOfWork().createPreparedStatement(countNotificationsSQL);
+        final ResultSet rs = countNotificationsStatement.executeQuery()) {
+      int index = 1;
+      rs.next();
+      return rs.getInt(index);
     } catch (SQLException x) {
       throw new RuntimeException(x);
     }

--- a/src/main/java/infrastructure/NotificationRepository.java
+++ b/src/main/java/infrastructure/NotificationRepository.java
@@ -143,4 +143,23 @@ public final class NotificationRepository extends SQLRepository
       span.finish();
     }
   }
+
+  /**
+   * Retrieves the number of notifications within the repository.
+   *
+   * @return The number of notifications within the repository.
+   */
+  @Override
+  public int size() {
+    final Span span =
+        this.tracer
+            .buildSpan("NotificationRepository#size")
+            .asChildOf(this.tracer.activeSpan())
+            .start();
+    try (final Scope scope = this.tracer.scopeManager().activate(span, false)) {
+      return this.notificationDataMapper.count();
+    } finally {
+      span.finish();
+    }
+  }
 }

--- a/src/main/java/infrastructure/Repository.java
+++ b/src/main/java/infrastructure/Repository.java
@@ -49,4 +49,11 @@ public interface Repository<T extends Entity<I>, I> {
    * @return The entities matching the provided {@link Query}.
    */
   Set<T> get(Query<T> query);
+
+  /**
+   * Retrieves the number of entities within the repository.
+   *
+   * @return The number of entities within the repository.
+   */
+  int size();
 }

--- a/src/main/java/infrastructure/TargetDataMapper.java
+++ b/src/main/java/infrastructure/TargetDataMapper.java
@@ -156,6 +156,21 @@ final class TargetDataMapper extends DataMapper {
     return sql;
   }
 
+  private String countTargetsSQL() {
+    DataMap targetDataMap = this.targetMetadata.getDataMap();
+    StringBuilder sb =
+        new StringBuilder()
+            .append("SELECT ")
+            .append("COUNT(*) ")
+            .append("FROM ")
+            .append(targetDataMap.getTableName())
+            .append(" AS ")
+            .append(targetDataMap.getTableAlias());
+    String sql = sb.toString();
+    this.logger.debug(sql);
+    return sql;
+  }
+
   Set<Target> findForNotification(UUID notificationUUID) {
 
     String sql = this.findTargetsForNotificationSQL();
@@ -252,6 +267,20 @@ final class TargetDataMapper extends DataMapper {
 
       deleteTargetStatement.setString(index, uuid.toString());
       deleteTargetStatement.executeUpdate();
+    } catch (SQLException x) {
+      throw new RuntimeException(x);
+    }
+  }
+
+  int count() {
+
+    final String countTargetsSQL = this.countTargetsSQL();
+
+    try (final PreparedStatement countTargetsStatement =
+            this.getUnitOfWork().createPreparedStatement(countTargetsSQL);
+        final ResultSet rs = countTargetsStatement.executeQuery()) {
+      int index = 1;
+      return rs.getInt(index);
     } catch (SQLException x) {
       throw new RuntimeException(x);
     }

--- a/src/main/java/infrastructure/TargetRepository.java
+++ b/src/main/java/infrastructure/TargetRepository.java
@@ -136,4 +136,20 @@ public final class TargetRepository extends SQLRepository implements Repository<
       span.finish();
     }
   }
+
+  /**
+   * Retrieves the number of notifications within the repository.
+   *
+   * @return The number of notifications within the repository.
+   */
+  @Override
+  public int size() {
+    final Span span =
+        this.tracer.buildSpan("TargetRepository#size").asChildOf(this.tracer.activeSpan()).start();
+    try (final Scope scope = this.tracer.scopeManager().activate(span, false)) {
+      return this.targetDataMapper.count();
+    } finally {
+      span.finish();
+    }
+  }
 }


### PR DESCRIPTION
## Overview

- Introduces logic within `NotificationDataMapper` and `NotificationRepository` to retrieve the total number of notifications within the repository.
- Alters `SirenRepresentationFactory` to construct a notification collection representation that has links with `prev` and `next` relations, as well as a `total` property.
- Adds logic within `NotificationService` to retrieve the number of notifications within the `NotificationRepository`.
- Additional fixes and clean up to accomplish the goal of pagination for notification collection representations.