### PR TITLE
Utilize named loggers for injection.

### DIFF
--- a/src/main/java/LoggingModule.java
+++ b/src/main/java/LoggingModule.java
@@ -2,8 +2,15 @@ import api.filters.ConditionalGetFilter;
 import api.filters.ConditionalPutFilter;
 import api.interceptors.MetadataGetInterceptor;
 import api.interceptors.MetadataPutInterceptor;
+import application.services.AudienceService;
+import application.services.NotificationService;
+import application.services.TargetService;
 import configuration.NotiConfiguration;
+import infrastructure.services.RepresentationMetadataService;
+import infrastructure.services.SMSQueueService;
 import io.dropwizard.setup.Environment;
+import java.util.ArrayList;
+import java.util.List;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,30 +32,22 @@ public final class LoggingModule extends NotiModule {
               protected void configure() {
 
                 // retrieve logger instances.
-                final Logger notiLogger = LoggerFactory.getLogger(Noti.class);
-                final Logger conditionalGetFilterLogger =
-                    LoggerFactory.getLogger(ConditionalGetFilter.class);
-                final Logger conditionalPutFilterLogger =
-                    LoggerFactory.getLogger(ConditionalPutFilter.class);
-                final Logger metadataGetInterceptorLogger =
-                    LoggerFactory.getLogger(MetadataGetInterceptor.class);
-                final Logger metadataPutInterceptorLogger =
-                    LoggerFactory.getLogger(MetadataPutInterceptor.class);
+                List<Logger> loggers = new ArrayList<>();
+                loggers.add(LoggerFactory.getLogger(Noti.class));
+                loggers.add(LoggerFactory.getLogger(ConditionalGetFilter.class));
+                loggers.add(LoggerFactory.getLogger(ConditionalPutFilter.class));
+                loggers.add(LoggerFactory.getLogger(MetadataGetInterceptor.class));
+                loggers.add(LoggerFactory.getLogger(MetadataPutInterceptor.class));
+                loggers.add(LoggerFactory.getLogger(NotificationService.class));
+                loggers.add(LoggerFactory.getLogger(AudienceService.class));
+                loggers.add(LoggerFactory.getLogger(TargetService.class));
+                loggers.add(LoggerFactory.getLogger(SMSQueueService.class));
+                loggers.add(LoggerFactory.getLogger(RepresentationMetadataService.class));
 
                 // wire up logger instances.
-                this.bind(notiLogger).to(Logger.class).named(notiLogger.getName());
-                this.bind(conditionalGetFilterLogger)
-                    .to(Logger.class)
-                    .named(conditionalGetFilterLogger.getName());
-                this.bind(conditionalPutFilterLogger)
-                    .to(Logger.class)
-                    .named(conditionalPutFilterLogger.getName());
-                this.bind(metadataGetInterceptorLogger)
-                    .to(Logger.class)
-                    .named(metadataGetInterceptorLogger.getName());
-                this.bind(metadataPutInterceptorLogger)
-                    .to(Logger.class)
-                    .named(metadataPutInterceptorLogger.getName());
+                for (Logger logger : loggers) {
+                  this.bind(logger).to(Logger.class).named(logger.getName());
+                }
               }
             });
   }

--- a/src/main/java/configuration/configuration.yml
+++ b/src/main/java/configuration/configuration.yml
@@ -11,7 +11,7 @@ jaeger:
   serviceName: noti
 
 logging:
-  level: DEBUG
+  level: INFO
 
 kafka:
     producer:

--- a/src/main/java/infrastructure/AudienceDataMapper.java
+++ b/src/main/java/infrastructure/AudienceDataMapper.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import javax.inject.Named;
 import org.slf4j.Logger;
 
 final class AudienceDataMapper extends DataMapper {
@@ -21,7 +22,9 @@ final class AudienceDataMapper extends DataMapper {
   private final Logger logger;
 
   AudienceDataMapper(
-      SQLUnitOfWork unitOfWork, EntitySQLFactory<Audience, UUID> audienceFactory, Logger logger) {
+      SQLUnitOfWork unitOfWork,
+      EntitySQLFactory<Audience, UUID> audienceFactory,
+      @Named("infrastructure.AudienceDataMapper") Logger logger) {
     super(unitOfWork);
 
     this.audienceFactory = audienceFactory;

--- a/src/main/java/infrastructure/NotificationDataMapper.java
+++ b/src/main/java/infrastructure/NotificationDataMapper.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import javax.inject.Named;
 import org.slf4j.Logger;
 
 final class NotificationDataMapper extends DataMapper {
@@ -33,7 +34,7 @@ final class NotificationDataMapper extends DataMapper {
       EntitySQLFactory<Notification, UUID> notificationFactory,
       EntitySQLFactory<Target, UUID> targetFactory,
       EntitySQLFactory<Audience, UUID> audienceFactory,
-      Logger logger) {
+      @Named("infrastructure.NotificationDataMapper") Logger logger) {
     super(unitOfWork);
 
     this.notificationFactory = notificationFactory;

--- a/src/main/java/infrastructure/SQLRepositoryFactory.java
+++ b/src/main/java/infrastructure/SQLRepositoryFactory.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.jvnet.hk2.annotations.Service;
-import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Service
 public class SQLRepositoryFactory extends RepositoryFactory {
@@ -19,7 +19,6 @@ public class SQLRepositoryFactory extends RepositoryFactory {
   private final EntitySQLFactory<Notification, UUID> notificationFactory;
   private final EntitySQLFactory<Target, UUID> targetFactory;
   private final EntitySQLFactory<Audience, UUID> audienceFactory;
-  private final Logger logger;
   private final Tracer tracer;
 
   @Inject
@@ -27,22 +26,18 @@ public class SQLRepositoryFactory extends RepositoryFactory {
       @Named("NotificationSQLFactory") EntitySQLFactory<Notification, UUID> notificationFactory,
       @Named("TargetSQLFactory") EntitySQLFactory<Target, UUID> targetFactory,
       @Named("AudienceSQLFactory") EntitySQLFactory<Audience, UUID> audienceFactory,
-      Tracer tracer,
-      Logger logger) {
+      Tracer tracer) {
     this.notificationFactory = notificationFactory;
     this.targetFactory = targetFactory;
     this.audienceFactory = audienceFactory;
     this.tracer = tracer;
-    this.logger = logger;
   }
 
   @Override
   public Repository<Notification, UUID> createNotificationRepository(SQLUnitOfWork unitOfWork) {
-    final Span span =
-        this.tracer
-            .buildSpan("SQLRepositoryFactory#createNotificationRepository")
-            .asChildOf(this.tracer.activeSpan())
-            .start();
+    String className = SQLRepositoryFactory.class.getName();
+    String spanName = String.format("%s#createNotificationRepository", className);
+    final Span span = this.tracer.buildSpan(spanName).asChildOf(this.tracer.activeSpan()).start();
     try (final Scope scope = this.tracer.scopeManager().activate(span, false)) {
       return new NotificationRepository(
           unitOfWork,
@@ -52,8 +47,8 @@ public class SQLRepositoryFactory extends RepositoryFactory {
               this.notificationFactory,
               this.targetFactory,
               this.audienceFactory,
-              this.logger),
-          this.tracer); // both of these inherit from SQLRepository!
+              LoggerFactory.getLogger(NotificationDataMapper.class)),
+          this.tracer);
     } finally {
       span.finish();
     }
@@ -61,17 +56,16 @@ public class SQLRepositoryFactory extends RepositoryFactory {
 
   @Override
   public Repository<Target, UUID> createTargetRepository(SQLUnitOfWork unitOfWork) {
-    final Span span =
-        this.tracer
-            .buildSpan("SQLRepositoryFactory#createTargetRepository")
-            .asChildOf(this.tracer.activeSpan())
-            .start();
+    String className = SQLRepositoryFactory.class.getName();
+    String spanName = String.format("%s#createTargetRepository", className);
+    final Span span = this.tracer.buildSpan(spanName).asChildOf(this.tracer.activeSpan()).start();
     try (final Scope scope = this.tracer.scopeManager().activate(span, false)) {
       return new TargetRepository(
           unitOfWork,
           this.targetFactory,
-          new TargetDataMapper(unitOfWork, this.targetFactory, this.logger),
-          this.tracer); // both of these inherit from SQLRepository!
+          new TargetDataMapper(
+              unitOfWork, this.targetFactory, LoggerFactory.getLogger(TargetDataMapper.class)),
+          this.tracer);
     } finally {
       span.finish();
     }
@@ -79,17 +73,16 @@ public class SQLRepositoryFactory extends RepositoryFactory {
 
   @Override
   public Repository<Audience, UUID> createAudienceRepository(SQLUnitOfWork unitOfWork) {
-    final Span span =
-        this.tracer
-            .buildSpan("SQLRepositoryFactory#createAudienceRepository")
-            .asChildOf(this.tracer.activeSpan())
-            .start();
+    String className = SQLRepositoryFactory.class.getName();
+    String spanName = String.format("%s#createAudienceRepository", className);
+    final Span span = this.tracer.buildSpan(spanName).asChildOf(this.tracer.activeSpan()).start();
     try (final Scope scope = this.tracer.scopeManager().activate(span, false)) {
       return new AudienceRepository(
           unitOfWork,
           this.audienceFactory,
-          new AudienceDataMapper(unitOfWork, this.audienceFactory, this.logger),
-          this.tracer); // both of these inherit from SQL repository!
+          new AudienceDataMapper(
+              unitOfWork, this.audienceFactory, LoggerFactory.getLogger(AudienceDataMapper.class)),
+          this.tracer);
     } finally {
       span.finish();
     }

--- a/src/main/java/infrastructure/services/SMSQueueService.java
+++ b/src/main/java/infrastructure/services/SMSQueueService.java
@@ -10,6 +10,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.inject.Inject;
+import javax.inject.Named;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -70,7 +71,9 @@ public final class SMSQueueService implements MessageQueueService {
 
   @Inject
   public SMSQueueService(
-      Producer<String, GenericRecord> producer, MetricRegistry metricRegistry, Logger logger) {
+      Producer<String, GenericRecord> producer,
+      MetricRegistry metricRegistry,
+      @Named("infrastructure.services.SMSQueueService") Logger logger) {
     this.producer = producer;
     this.metricRegistry = metricRegistry;
     this.logger = logger;


### PR DESCRIPTION
## Overview
- Reorganized `LoggingModule` to contain a collection of `Logger` instances.
- Introduced logging into `NotificationService`, `TargetService`, and `AudienceService`.
- Renamed a few local variables in `NotificationService`, `TargetService`, ad `AudienceService`.
- Correctly created instances of `Logger` for `NotificationDataMapper`, `TargetDataMapper` and `AudienceDataMapper`.
  - Since these types are constructed as dependencies to repositories within `SQLRepository`, DI is not used. Therefore, `LoggerFactory` is utilized instead.