### PR TITLE
Freer/improve travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,13 @@ jobs:
         - 'npm --version'
         - 'node_modules/.bin/newman --version'
       script:
-        - 'mvn package -Dmaven.test.skip=true'
         - 'docker-compose --file ./docker/docker-compose.yml up -d'
         - 'echo "Waiting 45 seconds for service startup :)" && sleep 45 && echo "We woke! Time to get to work!"'
         - 'node_modules/.bin/newman run ./src/test/resources/noti_tests.postman_collection.json -e ./src/test/resources/noti_local.postman_environment.json --bail'
         - 'docker-compose -f ./docker/docker-compose.yml down'
 cache:
   directories:
+    - $HOME/target
     - $HOME/.m2/repository
     - $HOME/.sonar/cache
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ jobs:
     -
       stage: 'postman test'
       before_script:
-        - 'nvm install v8.12.0'
         - 'npm install newman'
         - 'node --version'
         - 'npm --version'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
   - oraclejdk8
 addons:
-  sonarqube:
+  sonarcloud:
     organization: freerjm-github
     token:
       secure: fFpgdyfwx6Go9B1izAGDPkWxm+B2azkblwUnwvTIKbOpUW8Cbj4UZbEP8bL/Pcyo/ixu62oWJ9z7vc5ykuDfEbrFBtIxYfFUPEKMzjOYWw/45RLOiabom1gYs0kIAjCOFmMQovOF1RMXyBsfnOmaV9szSsFTDqZdC2/wmJQ3FD6fm3Zxc5okPssw67R+6ldUAWnUW/KspeQwTp2+xZR4pRncCc3xfHv0MMt3VmC9gl8O+rPTEZ5I4ZLL4pFe8p98JBrFJn/+JhLNvWum2WIwpSBUKL6xGM2GRNZ45MuYGN9a8AR/3pS6PSKFctSVVVVgUIR6eX8AHl9q7CUcSsBTomVu92W1NnqN6Obqoo4NrvbOBCH5BLoJbQ022uUanGFjhc9zsyngQm0anCqx/d0M3LJxkJo+F+/eznZS8uJH6mfD8d6PCyLaTj5IuWmr1eVSI0fbsc1c+gIkL4U8SwoDcqFm3qiFdu5zkuo1YKd0XJhUwWvS75ZTN3SFVRjT0rr3VVD4HGD1/q42gtRk2es1TDvAfUa/VnlzHpDxNoXOwBbwdqVOAGtPAtq+QyXfeVXHqFFTbEkuP3FU20KLf11ASVf+E8bkEbznTfruSr/FVk5oBlJvMsj1r39MNNA0Tw7NPk39CsiLIKiAhZtCmJd4Y/cmyLApL/lXr6mhYJZSDho=

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
         - 'node_modules/.bin/newman --version'
       script:
         - 'docker-compose --file ./docker/docker-compose.yml up -d'
-        - 'echo "Waiting 45 seconds for service startup :)" && sleep 45 && echo "We woke! Time to get to work!"'
+        - 'sleep $SERVICE_STARTUP_SLEEP_SECONDS'
         - 'node_modules/.bin/newman run ./src/test/resources/noti_tests.postman_collection.json -e ./src/test/resources/noti_local.postman_environment.json --bail'
         - 'docker-compose -f ./docker/docker-compose.yml down'
 cache:


### PR DESCRIPTION
## Overview

- Removes commands to install specific version of `node`.
- Utilizes `$SERVICE_STARTUP_SLEEP_SECONDS` environment variable to specify the number of seconds to `sleep` after `docker-compose` has been invoked.
- Instead of running `mvn package` again in the `Postman Test` build, utilize cache directories.