### PR TITLE
Remove unused container ports.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,10 +23,6 @@ services:
     restart: always
     ports:
       - '80:80'
-      - '2003-2004:2003-2004'
-      - '2023-2024:2023-2024'
-      - '8126:8126'
-      - '8125:8125/udp'
   grafana:
     image: grafana/grafana
     restart: always
@@ -35,19 +31,10 @@ services:
   jaegar:
     image: 'jaegertracing/all-in-one:1.6'
     ports:
-      - '5775:5775/udp'
-      - '6831:6831/udp'
-      - '6832:6832/udp'
-      - '5778:5778'
       - '16686:16686'
-      - '14268:14268'
-      - '9411:9411'
   kafka:
     image: spotify/kafka
     restart: always
-    ports:
-      - '2181:2181'
-      - '9092:9092'
     env_file: ./kafka.env
   schema-registry:
     image: 'confluentinc/cp-schema-registry:4.1.0'


### PR DESCRIPTION
### Overview

- Docker Compose takes care of creating networks between the various containers ran from `docker-compose.yml`. Due to this, there is no reason for many of the ports currently exposed in the `docker-compose.yml` file, as they are only accessed by other containers.