### PR TITLE
Freer/pin surefire plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,11 @@
 					<target>1.8</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.0.0-M1</version>
+			</plugin>
 			<!-- http://www.dropwizard.io/1.2.0/docs/getting-started.html -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Overview

- When performing development on my Linux machine (Ubuntu), I was having difficulty running `mvn` commands.
  - Turns out, there is a [bug reported](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925) for OpenJDK 8 that impacts Maven.
  - The proposed fix mentioned leveraging `3.0.0-M1` of the Surefire plugin to mitigate.