### PR TITLE
Refactor notification states. Introduce message update on notification domain object.

### DIFF
--- a/src/main/java/application/services/NotificationService.java
+++ b/src/main/java/application/services/NotificationService.java
@@ -405,12 +405,7 @@ public final class NotificationService implements application.NotificationServic
       }
 
       // update the message.
-      Message _existing_message = _notification.message(_message.getId());
-
-      // TODO - use state pattern instead to enforce invarients. throw error
-      // if the provided status is invalid.
-      _existing_message.setStatus(_message.getStatus());
-      _existing_message.setExternalId(_message.getExternalId());
+      _notification.message(_message);
       notificationRepository.put(_notification);
       unitOfWork.save();
     } catch (Exception x) {

--- a/src/main/java/domain/FailedState.java
+++ b/src/main/java/domain/FailedState.java
@@ -3,8 +3,9 @@ package domain;
 public class FailedState extends NotificationState {
 
   @Override
-  public void changeStatus(Notification notification) {
+  public void next(Notification notification) {
     // valid transitions:
     //	--> (NONE) FailedState.
+    notification.setState(this);
   }
 }

--- a/src/main/java/domain/Message.java
+++ b/src/main/java/domain/Message.java
@@ -73,6 +73,16 @@ public class Message extends Entity<Integer> {
     this.externalId = externalId;
   }
 
+  public Message(Message message) {
+    this(
+        message.getId(),
+        message.getFrom(),
+        message.getTo(),
+        message.getContent(),
+        message.getStatus(),
+        message.getExternalId());
+  }
+
   @Override
   public boolean isAggregateRoot() {
     return false;

--- a/src/main/java/domain/Notification.java
+++ b/src/main/java/domain/Notification.java
@@ -107,6 +107,7 @@ public class Notification extends Entity<UUID> {
 
   protected void sentAt(Date sentAt) {
     this.sentAt = sentAt;
+    this.state().next(this);
   }
 
   private void content(String content) {
@@ -115,6 +116,7 @@ public class Notification extends Entity<UUID> {
 
   private void sendAt(Date sendAt) {
     this.sendAt = sendAt;
+    this.state().next(this);
   }
 
   public void directRecipients(Set<Target> targets) {
@@ -139,6 +141,7 @@ public class Notification extends Entity<UUID> {
     } else {
       this.messages = messages;
     }
+    this.state().next(this);
   }
 
   public boolean containsMessage(Message message) {
@@ -188,6 +191,31 @@ public class Notification extends Entity<UUID> {
       }
     }
 
-    return desiredMessage;
+    return new Message(desiredMessage);
+  }
+
+  public void messageExternalID(Integer messageID, String externalID) {
+    if (this.containsMessage(messageID)) {
+      Message message = this.message(messageID);
+      message.setExternalId(externalID);
+      this.state().next(this);
+    }
+  }
+
+  public void messageStatus(Integer messageID, MessageStatus status) {
+    if (this.containsMessage(messageID)) {
+      Message message = this.message(messageID);
+      message.setStatus(status);
+      this.state().next(this);
+    }
+  }
+
+  public void message(Message message) {
+    if (this.containsMessage(message.getId())) {
+      Message _message = this.message(message.getId());
+      _message.setExternalId(message.getExternalId());
+      _message.setStatus(message.getStatus());
+      this.state().next(this);
+    }
   }
 }

--- a/src/main/java/domain/NotificationState.java
+++ b/src/main/java/domain/NotificationState.java
@@ -1,9 +1,9 @@
 package domain;
 
 public abstract class NotificationState {
-  abstract void changeStatus(final Notification notification);
+  abstract void next(final Notification notification);
 
-  boolean changeToFailedState(final Notification notification) {
+  boolean failed(final Notification notification) {
     final int TOTAL_MESSAGE_COUNT = notification.messages().size();
     int failedCount = 0;
 
@@ -15,7 +15,7 @@ public abstract class NotificationState {
     return failedCount == TOTAL_MESSAGE_COUNT;
   }
 
-  boolean changeToSentState(final Notification notification) {
+  boolean sent(final Notification notification) {
     final int TOTAL_MESSAGE_COUNT = notification.messages().size();
 
     int sentCount = 0, deliveredCount = 0;
@@ -30,7 +30,7 @@ public abstract class NotificationState {
     return sentCount + deliveredCount == TOTAL_MESSAGE_COUNT;
   }
 
-  boolean changeToSendingState(final Notification notification) {
+  boolean sending(final Notification notification) {
     final int TOTAL_MESSAGE_COUNT = notification.messages().size();
 
     int sentCount = 0, deliveredCount = 0, pendingCount = 0;

--- a/src/main/java/domain/PendingState.java
+++ b/src/main/java/domain/PendingState.java
@@ -3,17 +3,17 @@ package domain;
 public class PendingState extends NotificationState {
 
   @Override
-  public void changeStatus(Notification notification) {
+  public void next(Notification notification) {
 
     // valid transitions:
     //	-->	SENDING.
     //	-->	FAILED.
     //	--> (NONE) PENDING.
 
-    if (this.changeToFailedState(notification)) {
+    if (this.failed(notification)) {
       notification.status(NotificationStatus.FAILED);
       notification.setState(new FailedState());
-    } else if (this.changeToSendingState(notification)) {
+    } else if (this.sending(notification)) {
       notification.status(NotificationStatus.SENDING);
       notification.setState(new SendingState());
     }

--- a/src/main/java/domain/SendingState.java
+++ b/src/main/java/domain/SendingState.java
@@ -3,22 +3,19 @@ package domain;
 public class SendingState extends NotificationState {
 
   @Override
-  public void changeStatus(Notification notification) {
+  public void next(Notification notification) {
 
     // valid transitions:
     //	-->	SENT.
     //	-->	FAILED.
     //	--> (NONE) SENDING.
 
-    if (this.changeToFailedState(notification)) {
+    if (this.failed(notification)) {
       notification.status(NotificationStatus.FAILED);
       notification.setState(new FailedState());
-    } else if (this.changeToSentState(notification)) {
+    } else if (this.sent(notification)) {
       notification.status(NotificationStatus.SENT);
       notification.setState(new SentState());
     }
-
-    // change.
-    notification.setState(this);
   }
 }

--- a/src/main/java/domain/SentState.java
+++ b/src/main/java/domain/SentState.java
@@ -3,8 +3,9 @@ package domain;
 public class SentState extends NotificationState {
 
   @Override
-  public void changeStatus(final Notification notification) {
+  public void next(final Notification notification) {
     // valid transitions:
     //	--> (NONE) SENDING.
+    notification.setState(this);
   }
 }


### PR DESCRIPTION
## Overview

- Performs some simple refactoring within the notification state classes.
  - Changes method signature to be cleaner (`next`).
  - Changes method signatures of private functions that do the heavy lifting:
    - `failed`
    - `sent`
    - `sending`
- Wires up `domain.Notification` to update state during various operations.
- Removes message update code that is in violation with DDD.
  - A reference to an internal entity (`Message`) within the `Notification` aggregate was being held, which was then used to alter the state of the message without satisfying the invariants of the `Notification` aggregate.
  - Introduces new methods on `domain.Notification` to allow for message changes.
    - `messageExternalID(String externalID)`
    - `messageStatus(MessageStatus status)`
    - `message(Message message)`