### PR TITLE
Freer/fix representation selection

### DIFF
--- a/src/main/java/api/resources/Resource.java
+++ b/src/main/java/api/resources/Resource.java
@@ -21,13 +21,14 @@ public abstract class Resource {
   }
 
   public RepresentationFactory getRepresentationFactory(HttpHeaders headers) {
-    RepresentationFactory representationFactory = null;
     for (MediaType acceptableMediaType : headers.getAcceptableMediaTypes()) {
-      if (this.representationIndustry.containsKey(acceptableMediaType)) {
-        representationFactory = this.representationIndustry.get(acceptableMediaType);
-        break;
+      for (Map.Entry<MediaType, RepresentationFactory> factoryEntry :
+          this.representationIndustry.entrySet()) {
+        if (acceptableMediaType.isCompatible(factoryEntry.getKey())) {
+          return factoryEntry.getValue();
+        }
       }
     }
-    return representationFactory;
+    return null;
   }
 }


### PR DESCRIPTION
## Overview

- Fixes issue where representation can only be generated if there is an _*exact*_ match on the media types used as keys for the `RepresentationFactory` instances.
  - Fix lies in the utilization of [`MediaType#isCompatible`](
https://docs.oracle.com/javaee/7/api/javax/ws/rs/core/MediaType.html#isCompatible-javax.ws.rs.core.MediaType), which ultimately does all the heavy lifting of determining if one media type value is compatible with another.