### PR TITLE
Introduce console log for Postman PUT requests.

### DIFF
--- a/src/test/resources/noti_tests.postman_collection.json
+++ b/src/test/resources/noti_tests.postman_collection.json
@@ -22,6 +22,7 @@
 									"pm.test(\"Status code = 200 OK\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
+									"console.log(\"Response:\");",
 									"console.log(pm.response.text());"
 								]
 							}
@@ -76,6 +77,7 @@
 									"//set globals.",
 									"var location = postman.getResponseHeader(\"Location\");",
 									"pm.globals.set(\"audience_location\", location);",
+									"console.log(\"Response:\");",
 									"console.log(pm.response.text());"
 								]
 							}
@@ -148,6 +150,7 @@
 									"});",
 									"",
 									"//set globals.",
+									"console.log(\"Response:\");",
 									"console.log(pm.response.text());",
 									"pm.globals.set(\"audience_representation\", pm.response.text());"
 								]
@@ -204,6 +207,7 @@
 									"",
 									"//clear globals.",
 									"pm.globals.unset(\"audience_representation\");",
+									"console.log(\"Response:\");",
 									"console.log(pm.response.text());"
 								]
 							}
@@ -260,6 +264,7 @@
 									"//set globals.",
 									"var location = postman.getResponseHeader(\"Location\");",
 									"pm.globals.set(\"target_location\", location);",
+									"console.log(\"Response:\");",
 									"console.log(pm.response.text());"
 								]
 							}
@@ -336,6 +341,7 @@
 									"pm.globals.set(\"target_uuid\", \"\\\"\" + target.uuid + \"\\\"\");",
 									"pm.globals.set(\"target_name\", \"\\\"\" + target.name + \"\\\"\");",
 									"pm.globals.set(\"target_phone_number\", \"\\\"\" + target.phoneNumber + \"\\\"\");",
+									"console.log(\"Response:\");",
 									"console.log(pm.response.text());"
 								],
 								"type": "text/javascript"
@@ -391,6 +397,7 @@
 									"",
 									"//clear globals.",
 									"pm.globals.unset(\"target_representation\");",
+									"console.log(\"Response:\");",
 									"console.log(pm.response.text());"
 								],
 								"type": "text/javascript"
@@ -435,6 +442,7 @@
 									"pm.test(\"Status code = 200 OK\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
+									"console.log(\"Response:\");",
 									"console.log(pm.response.text());"
 								]
 							}
@@ -494,6 +502,7 @@
 									"pm.globals.unset(\"target_uuid\");",
 									"pm.globals.unset(\"target_name\");",
 									"pm.globals.unset(\"target_phone_number\");",
+									"console.log(\"Response:\");",
 									"console.log(pm.response.text());"
 								],
 								"type": "text/javascript"
@@ -569,6 +578,7 @@
 									"",
 									"//set globals.",
 									"pm.globals.set(\"notification_representation\", pm.response.text());",
+									"console.log(\"Response:\");",
 									"console.log(pm.response.text());"
 								],
 								"type": "text/javascript"
@@ -628,6 +638,7 @@
 									"",
 									"//clear globals.",
 									"pm.globals.unset(\"notification_representation\");",
+									"console.log(\"Response:\");",
 									"console.log(pm.response.text());"
 								],
 								"type": "text/javascript"
@@ -676,6 +687,7 @@
 									"",
 									"//clear globals.",
 									"pm.globals.unset(\"audience_location\");",
+									"console.log(\"Response:\");",
 									"console.log(pm.response.text());"
 								]
 							}
@@ -716,6 +728,7 @@
 									"",
 									"//clear globals.",
 									"pm.globals.unset(\"target_location\");",
+									"console.log(\"Response:\");",
 									"console.log(pm.response.text());"
 								]
 							}
@@ -755,6 +768,7 @@
 									"",
 									"//clear globals.",
 									"pm.globals.unset(\"notification_location\");",
+									"console.log(\"Response:\");",
 									"console.log(pm.response.text());"
 								],
 								"type": "text/javascript"

--- a/src/test/resources/noti_tests.postman_collection.json
+++ b/src/test/resources/noti_tests.postman_collection.json
@@ -21,7 +21,8 @@
 									"//tests.",
 									"pm.test(\"Status code = 200 OK\", function () {",
 									"    pm.response.to.have.status(200);",
-									"});"
+									"});",
+									"console.log(pm.response.text());"
 								]
 							}
 						}
@@ -74,7 +75,8 @@
 									"",
 									"//set globals.",
 									"var location = postman.getResponseHeader(\"Location\");",
-									"pm.globals.set(\"audience_location\", location);"
+									"pm.globals.set(\"audience_location\", location);",
+									"console.log(pm.response.text());"
 								]
 							}
 						}
@@ -146,6 +148,7 @@
 									"});",
 									"",
 									"//set globals.",
+									"console.log(pm.response.text());",
 									"pm.globals.set(\"audience_representation\", pm.response.text());"
 								]
 							}
@@ -200,7 +203,8 @@
 									"});",
 									"",
 									"//clear globals.",
-									"pm.globals.unset(\"audience_representation\");"
+									"pm.globals.unset(\"audience_representation\");",
+									"console.log(pm.response.text());"
 								]
 							}
 						}
@@ -255,7 +259,8 @@
 									"",
 									"//set globals.",
 									"var location = postman.getResponseHeader(\"Location\");",
-									"pm.globals.set(\"target_location\", location);"
+									"pm.globals.set(\"target_location\", location);",
+									"console.log(pm.response.text());"
 								]
 							}
 						}
@@ -330,7 +335,8 @@
 									"var target = JSON.parse(pm.response.text());",
 									"pm.globals.set(\"target_uuid\", \"\\\"\" + target.uuid + \"\\\"\");",
 									"pm.globals.set(\"target_name\", \"\\\"\" + target.name + \"\\\"\");",
-									"pm.globals.set(\"target_phone_number\", \"\\\"\" + target.phoneNumber + \"\\\"\");"
+									"pm.globals.set(\"target_phone_number\", \"\\\"\" + target.phoneNumber + \"\\\"\");",
+									"console.log(pm.response.text());"
 								],
 								"type": "text/javascript"
 							}
@@ -384,7 +390,8 @@
 									"});",
 									"",
 									"//clear globals.",
-									"pm.globals.unset(\"target_representation\");"
+									"pm.globals.unset(\"target_representation\");",
+									"console.log(pm.response.text());"
 								],
 								"type": "text/javascript"
 							}
@@ -427,7 +434,8 @@
 								"exec": [
 									"pm.test(\"Status code = 200 OK\", function () {",
 									"    pm.response.to.have.status(200);",
-									"});"
+									"});",
+									"console.log(pm.response.text());"
 								]
 							}
 						}
@@ -485,7 +493,8 @@
 									"//clear globals.",
 									"pm.globals.unset(\"target_uuid\");",
 									"pm.globals.unset(\"target_name\");",
-									"pm.globals.unset(\"target_phone_number\");"
+									"pm.globals.unset(\"target_phone_number\");",
+									"console.log(pm.response.text());"
 								],
 								"type": "text/javascript"
 							}
@@ -559,7 +568,8 @@
 									"});",
 									"",
 									"//set globals.",
-									"pm.globals.set(\"notification_representation\", pm.response.text());"
+									"pm.globals.set(\"notification_representation\", pm.response.text());",
+									"console.log(pm.response.text());"
 								],
 								"type": "text/javascript"
 							}
@@ -617,7 +627,8 @@
 									"});",
 									"",
 									"//clear globals.",
-									"pm.globals.unset(\"notification_representation\");"
+									"pm.globals.unset(\"notification_representation\");",
+									"console.log(pm.response.text());"
 								],
 								"type": "text/javascript"
 							}
@@ -664,7 +675,8 @@
 									"});",
 									"",
 									"//clear globals.",
-									"pm.globals.unset(\"audience_location\");"
+									"pm.globals.unset(\"audience_location\");",
+									"console.log(pm.response.text());"
 								]
 							}
 						}
@@ -703,7 +715,8 @@
 									"});",
 									"",
 									"//clear globals.",
-									"pm.globals.unset(\"target_location\");"
+									"pm.globals.unset(\"target_location\");",
+									"console.log(pm.response.text());"
 								]
 							}
 						}
@@ -741,7 +754,8 @@
 									"});",
 									"",
 									"//clear globals.",
-									"pm.globals.unset(\"notification_location\");"
+									"pm.globals.unset(\"notification_location\");",
+									"console.log(pm.response.text());"
 								],
 								"type": "text/javascript"
 							}

--- a/src/test/resources/noti_tests.postman_collection.json
+++ b/src/test/resources/noti_tests.postman_collection.json
@@ -364,6 +364,7 @@
 								"id": "83172d7c-8469-428c-a234-996a22aaa8a4",
 								"exec": [
 									"var json_text = pm.globals.get(\"target_representation\");",
+									"console.log(json_text);",
 									"var json_data = JSON.parse(json_text);",
 									"",
 									"json_data.name = \"Updated Test Target\";",
@@ -596,6 +597,7 @@
 								"id": "83172d7c-8469-428c-a234-996a22aaa8a4",
 								"exec": [
 									"var json_text = pm.globals.get(\"notification_representation\");",
+									"console.log(json_text);",
 									"var json_data = JSON.parse(json_text);",
 									"",
 									"json_data.content = \"Updated Content!\";",
@@ -1152,6 +1154,7 @@
 								"id": "9866b6b3-0478-49c5-8a56-a49b2275e1b6",
 								"exec": [
 									"var json_text = pm.globals.get(\"target_representation\");",
+									"console.log(json_text);",
 									"var json_data = JSON.parse(json_text);",
 									"var properties = json_data.properties;",
 									"",
@@ -1439,6 +1442,7 @@
 								"id": "83172d7c-8469-428c-a234-996a22aaa8a4",
 								"exec": [
 									"var json_text = pm.globals.get(\"notification_representation\");",
+									"console.log(json_text);",
 									"var json_data = JSON.parse(json_text);",
 									"",
 									"json_data.content = \"Updated Content!\";",


### PR DESCRIPTION
## Overview

- When the Postman tests fail, currently it difficult to know what was sent in the body of the request. For example, nearly all `POST` and `PUT` requests currently do not log what representation was sent in the test.
  - Given `newman` has decent support for displaying the log statements within the test output, these change include printing out the representations sent in `POST` and `PUT` requests.
  - In addition, these changes also log the response representations.