### PR TITLE
Freer/fix status propogation

### DIFF
--- a/src/main/java/api/representations/json/NotificationStatus.java
+++ b/src/main/java/api/representations/json/NotificationStatus.java
@@ -5,11 +5,17 @@ public enum NotificationStatus {
   /** Indicates that the notification has not yet been sent. */
   PENDING("PENDING"),
 
+  /** Indicates that the notification in currently being sent. */
+  SENDING("SENDING"),
+
   /** Indicates that the notification has been sent. */
   SENT("SENT"),
 
   /** Indicates that the notification was cancelled prior to being sent. */
-  CANCELLED("CANCELLED");
+  CANCELLED("CANCELLED"),
+
+  /** Indicates that the notification did not send to anyone. */
+  FAILED("FAILED");
 
   private final String status;
 

--- a/src/main/java/api/representations/xml/NotificationStatus.java
+++ b/src/main/java/api/representations/xml/NotificationStatus.java
@@ -5,11 +5,17 @@ public enum NotificationStatus {
   /** Indicates that the notification has not yet been sent. */
   PENDING("PENDING"),
 
+  /** Indicates that the notification in currently being sent. */
+  SENDING("SENDING"),
+
   /** Indicates that the notification has been sent. */
   SENT("SENT"),
 
   /** Indicates that the notification was cancelled prior to being sent. */
-  CANCELLED("CANCELLED");
+  CANCELLED("CANCELLED"),
+
+  /** Indicates that the notification did not send to anyone. */
+  FAILED("FAILED");
 
   private final String status;
 

--- a/src/main/java/api/representations/yaml/NotificationStatus.java
+++ b/src/main/java/api/representations/yaml/NotificationStatus.java
@@ -5,11 +5,17 @@ public enum NotificationStatus {
   /** Indicates that the notification has not yet been sent. */
   PENDING("PENDING"),
 
+  /** Indicates that the notification in currently being sent. */
+  SENDING("SENDING"),
+
   /** Indicates that the notification has been sent. */
   SENT("SENT"),
 
   /** Indicates that the notification was cancelled prior to being sent. */
-  CANCELLED("CANCELLED");
+  CANCELLED("CANCELLED"),
+
+  /** Indicates that the notification did not send to anyone. */
+  FAILED("FAILED");
 
   private final String status;
 

--- a/src/main/java/application/NotificationStatus.java
+++ b/src/main/java/application/NotificationStatus.java
@@ -5,11 +5,17 @@ public enum NotificationStatus {
   /** Indicates that the notification has not yet been sent. */
   PENDING("PENDING"),
 
+  /** Indicates that the notification in currently being sent. */
+  SENDING("SENDING"),
+
   /** Indicates that the notification has been sent. */
   SENT("SENT"),
 
   /** Indicates that the notification was cancelled prior to being sent. */
-  CANCELLED("CANCELLED");
+  CANCELLED("CANCELLED"),
+
+  /** Indicates that the notification did not send to anyone. */
+  FAILED("FAILED");
 
   private String status;
 

--- a/src/main/java/domain/Notification.java
+++ b/src/main/java/domain/Notification.java
@@ -28,22 +28,22 @@ public class Notification extends Entity<UUID> {
     super(uuid);
     this.setState(new PendingState());
     this.status = NotificationStatus.PENDING;
+    this.messages(messages);
     this.content(content);
     this.sendAt(sendAt);
     this.sentAt(sentAt);
     this.directRecipients(targets);
     this.audiences(audiences);
-    this.messages(messages);
   }
 
   public Notification(Notification notification) {
+    this.setState(notification.state());
+    this.messages(notification.messages());
     this.content(notification.content());
     this.sendAt(notification.sendAt());
     this.sentAt(notification.sentAt());
     this.directRecipients(notification.directRecipients());
-    this.messages(notification.messages());
     this.audiences(notification.audiences());
-    this.setState(notification.state());
   }
 
   @Override
@@ -175,6 +175,11 @@ public class Notification extends Entity<UUID> {
   }
 
   public Message message(Integer messageId) {
+    Message desiredMessage = this._message(messageId);
+    return new Message(desiredMessage);
+  }
+
+  private Message _message(Integer messageId) {
     if (messageId == null) {
       throw new IllegalArgumentException("The argument 'messageId' cannot be null.");
     }
@@ -191,12 +196,12 @@ public class Notification extends Entity<UUID> {
       }
     }
 
-    return new Message(desiredMessage);
+    return desiredMessage;
   }
 
   public void messageExternalID(Integer messageID, String externalID) {
     if (this.containsMessage(messageID)) {
-      Message message = this.message(messageID);
+      Message message = this._message(messageID);
       message.setExternalId(externalID);
       this.state().next(this);
     }
@@ -204,7 +209,7 @@ public class Notification extends Entity<UUID> {
 
   public void messageStatus(Integer messageID, MessageStatus status) {
     if (this.containsMessage(messageID)) {
-      Message message = this.message(messageID);
+      Message message = this._message(messageID);
       message.setStatus(status);
       this.state().next(this);
     }
@@ -212,7 +217,7 @@ public class Notification extends Entity<UUID> {
 
   public void message(Message message) {
     if (this.containsMessage(message.getId())) {
-      Message _message = this.message(message.getId());
+      Message _message = this._message(message.getId());
       _message.setExternalId(message.getExternalId());
       _message.setStatus(message.getStatus());
       this.state().next(this);

--- a/src/main/java/domain/NotificationState.java
+++ b/src/main/java/domain/NotificationState.java
@@ -5,8 +5,8 @@ public abstract class NotificationState {
 
   boolean failed(final Notification notification) {
     final int TOTAL_MESSAGE_COUNT = notification.messages().size();
+    if (TOTAL_MESSAGE_COUNT == 0) return false;
     int failedCount = 0;
-
     for (Message message : notification.messages()) {
       if (message.getStatus() == MessageStatus.FAILED) {
         failedCount++;
@@ -17,7 +17,7 @@ public abstract class NotificationState {
 
   boolean sent(final Notification notification) {
     final int TOTAL_MESSAGE_COUNT = notification.messages().size();
-
+    if (TOTAL_MESSAGE_COUNT == 0) return false;
     int sentCount = 0, deliveredCount = 0;
     for (Message message : notification.messages()) {
       if (message.getStatus() == MessageStatus.SENT) {
@@ -32,7 +32,7 @@ public abstract class NotificationState {
 
   boolean sending(final Notification notification) {
     final int TOTAL_MESSAGE_COUNT = notification.messages().size();
-
+    if (TOTAL_MESSAGE_COUNT == 0) return false;
     int sentCount = 0, deliveredCount = 0, pendingCount = 0;
     for (Message message : notification.messages()) {
       if (message.getStatus() == MessageStatus.SENT) {

--- a/src/main/java/domain/PendingState.java
+++ b/src/main/java/domain/PendingState.java
@@ -7,6 +7,8 @@ public class PendingState extends NotificationState {
 
     // valid transitions:
     //	-->	SENDING.
+    //	--> SENT
+    //	  - Tackles single message notification case.
     //	-->	FAILED.
     //	--> (NONE) PENDING.
 
@@ -16,6 +18,9 @@ public class PendingState extends NotificationState {
     } else if (this.sending(notification)) {
       notification.status(NotificationStatus.SENDING);
       notification.setState(new SendingState());
+    } else if (this.sent(notification)) {
+      notification.status(NotificationStatus.SENT);
+      notification.setState(new SentState());
     }
   }
 }


### PR DESCRIPTION
## Overview

- No longer apply state transition logic if there are no messages to assess.
- Aligns notification statuses between `domain`, `application`, and `api` layers.
- Add in state transition between `PENDING` and `SENT`.
  - Addresses the use case where a notification has a single message, which means there will be no `SENDING` state possible.
- Fixes an issue where message updates weren’t persisting.